### PR TITLE
update jsdom dependency, bump version to 0.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bowman-exports",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "description": "plugin for Bowman that finds exposed globals and sets the export for requiring with browserify",
   "main": "index.js",
   "scripts": {
@@ -9,7 +9,7 @@
   "dependencies": {
     "lodash": "^3.0.0",
     "q": "^1.1.2",
-    "jsdom": "^1.0.3"
+    "jsdom": "^9.0.0"
   },
   "peerDependencies": {
     "bowman": "*"


### PR DESCRIPTION
jsdom ^9 is the last, best version to run on node < 6. jsdom ^1
didn't run on 4 because of a native dependency that clashed with
now-built-in functionality.